### PR TITLE
Fix file association for Nudhi Lang

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,8 @@ use std::fs;
 use std::process::exit;
 use std::process::Command;
 use std::io;
-
+use winreg::enums::*;
+use winreg::RegKey;
 
 // Structure to store variables (as strings or integers)
 enum Value {
@@ -186,7 +187,24 @@ fn interpret(source_code: &str, variables: &mut HashMap<String, Value>) {
     }
 }
 
+fn register_file_association() {
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    let (nudhi_key, _) = hkcu.create_subkey("Software\\Classes\\.nd").unwrap();
+    nudhi_key.set_value("", &"nudhi_lang_file").unwrap();
+
+    let (nudhi_file_key, _) = hkcu.create_subkey("Software\\Classes\\nudhi_lang_file").unwrap();
+    nudhi_file_key.set_value("", &"Nudhi Lang File").unwrap();
+    nudhi_file_key.set_value("FriendlyTypeName", &"Nudhi Lang File").unwrap();
+
+    let (shell_key, _) = nudhi_file_key.create_subkey("shell\\open\\command").unwrap();
+    let exe_path = std::env::current_exe().unwrap();
+    let exe_path_str = exe_path.to_str().unwrap();
+    shell_key.set_value("", &format!("\"{}\" \"%1\"", exe_path_str)).unwrap();
+}
+
 fn main() {
+    register_file_association();
+
     let args: Vec<String> = env::args().collect();
     if args.len() != 2 {
         eprintln!("Usage: {} <source_file>", args[0]);


### PR DESCRIPTION
Fixes #1

Add functionality to handle file associations and double-click events in Windows Explorer for Nudhi Lang files.

* Import `winreg` to handle Windows registry operations.
* Add `register_file_association` function to register `.nd` file extension with Nudhi Lang.
* Call `register_file_association` function in `main` to register file association.
* Update `main` function to handle file associations and double-click events.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nudhi-lang/nudhi_lang/pull/2?shareId=e8bfd593-b15b-499d-b6bc-ce131529e312).